### PR TITLE
Fix style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+  # force all unspecified python hooks to run python3
+  python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8

--- a/filtering.py
+++ b/filtering.py
@@ -2,67 +2,78 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 
+
 class PatchworkHomePage:
 
-  URL = 'http://127.0.0.1:8000/project/patchwork/list/'
-  
-  submitter_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][2]//div//div//div'
-  state_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][3]//div//select'
-  search_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][4]//div//input'
-  archived_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][5]//div'
-  delegate_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][6]//div//select'
-  submit_filter = '//button[@type="submit"]'
-  
-  SHOW_PATCH_FILTERS = (By.LINK_TEXT, 'Show patches with') 
-  SERIES_INPUT = (By.ID, 'series_input')
-  
-  SUBMITTER_INPUT = (By.XPATH, submitter_xpath)
-  STATE_INPUT = (By.XPATH, state_xpath)
-  SEARCH_INPUT = (By.XPATH, search_xpath)
-  ARCHIVED_INPUT = (By.XPATH, archived_xpath)
-  DELEGATE_FILTER = (By.XPATH, delegate_xpath)
-  SUBMIT_FILTER = (By.XPATH, submit_filter)
-  
-  def __init__(self, browser):
-    self.browser = browser
-    
-  def load(self):
-    self.browser.get(self.URL)
-    
-  def show_filters(self):
-    show_patch_filters = self.browser.find_element(*self.SHOW_PATCH_FILTERS)
-    show_patch_filters.click()
-    
-  def filter_by_series(self, title):
-    series_input = self.browser.find_element(*self.SERIES_INPUT)
-    series_input.send_keys(title + Keys.RETURN)
-  
-  def filter_by_submitter(self, name):
-    submitter_input = Select(self.browser.find_element(*self.SUBMITTER_INPUT))
-    submitter_input.select_by_index(1)
-       
-  def filter_by_state(self, state):
-    state_input = Select(self.browser.find_element(*self.STATE_INPUT))
-    state_input.select_by_visible_text(state)
-    
-  def filter_by_search_term(self, term):
-    search_input = self.browser.find_element(*self.SEARCH_INPUT)
-    search_input.send_keys(term + Keys.RETURN)
+    URL = "http://127.0.0.1:8000/project/patchwork/list/"
 
-  def filter_by_archived(self, archived):
-    archived_input = self.browser.find_element(*self.ARCHIVED_INPUT).find_elements_by_tag_name('input')
-    submit_filter = self.browser.find_element(*self.SUBMIT_FILTER)
-    
-    for input in archived_input:
-      input.get_attribute('value')
-      if(input == archived):
-        input.click()
-        
-    submit_filter.click()
-    
-  def filter_by_delegate(self, name):
-    delegate_filter = Select(self.browser.find_element(*self.DELEGATE_FILTER))
-    submit_filter = self.browser.find_element(*self.SUBMIT_FILTER)
-    delegate_filter.select_by_value(name)
-    
-    submit_filter.click()
+    submitter_xpath = (
+        '//div[@id="filterform"]//form//div[@class="form-group"][2]//div//div//div'
+    )
+    state_xpath = (
+        '//div[@id="filterform"]//form//div[@class="form-group"][3]//div//select'
+    )
+    search_xpath = (
+        '//div[@id="filterform"]//form//div[@class="form-group"][4]//div//input'
+    )
+    archived_xpath = '//div[@id="filterform"]//form//div[@class="form-group"][5]//div'
+    delegate_xpath = (
+        '//div[@id="filterform"]//form//div[@class="form-group"][6]//div//select'
+    )
+    submit_filter = '//button[@type="submit"]'
+
+    SHOW_PATCH_FILTERS = (By.LINK_TEXT, "Show patches with")
+    SERIES_INPUT = (By.ID, "series_input")
+
+    SUBMITTER_INPUT = (By.XPATH, submitter_xpath)
+    STATE_INPUT = (By.XPATH, state_xpath)
+    SEARCH_INPUT = (By.XPATH, search_xpath)
+    ARCHIVED_INPUT = (By.XPATH, archived_xpath)
+    DELEGATE_FILTER = (By.XPATH, delegate_xpath)
+    SUBMIT_FILTER = (By.XPATH, submit_filter)
+
+    def __init__(self, browser):
+        self.browser = browser
+
+    def load(self):
+        self.browser.get(self.URL)
+
+    def show_filters(self):
+        show_patch_filters = self.browser.find_element(*self.SHOW_PATCH_FILTERS)
+        show_patch_filters.click()
+
+    def filter_by_series(self, title):
+        series_input = self.browser.find_element(*self.SERIES_INPUT)
+        series_input.send_keys(title + Keys.RETURN)
+
+    def filter_by_submitter(self, name):
+        submitter_input = Select(self.browser.find_element(*self.SUBMITTER_INPUT))
+        submitter_input.select_by_index(1)
+
+    def filter_by_state(self, state):
+        state_input = Select(self.browser.find_element(*self.STATE_INPUT))
+        state_input.select_by_visible_text(state)
+
+    def filter_by_search_term(self, term):
+        search_input = self.browser.find_element(*self.SEARCH_INPUT)
+        search_input.send_keys(term + Keys.RETURN)
+
+    def filter_by_archived(self, archived):
+        archived_input = self.browser.find_element(
+            *self.ARCHIVED_INPUT
+        ).find_elements_by_tag_name("input")
+        submit_filter = self.browser.find_element(*self.SUBMIT_FILTER)
+
+        for input in archived_input:
+            input.get_attribute("value")
+            if input == archived:
+                input.click()
+
+        submit_filter.click()
+
+    def filter_by_delegate(self, name):
+        delegate_filter = Select(self.browser.find_element(*self.DELEGATE_FILTER))
+        submit_filter = self.browser.find_element(*self.SUBMIT_FILTER)
+        delegate_filter.select_by_value(name)
+
+        submit_filter.click()

--- a/result.py
+++ b/result.py
@@ -1,20 +1,17 @@
 from selenium.webdriver.common.by import By
 
+
 class FilteredPatchesResults:
-   
-  ACTIVE_FILTERS = (By.ID, 'filtersummary')
-  
-  def FILTERED_PATCHES(cls, phrase):
-    xpath = f"//tbody//*[contains(text(), '{phrase}')]"
-    return (By.XPATH, xpath)
-    
-  def __init__(self, browser):
-    self.browser = browser
-    
-  def active_filters_contains(self, filter_type):
-    active_filters = self.browser.find_element(*self.ACTIVE_FILTERS).text
-    return active_filters.find(filter_type)
-  
-  
-  
-  
+
+    ACTIVE_FILTERS = (By.ID, "filtersummary")
+
+    def FILTERED_PATCHES(cls, phrase):
+        xpath = f"//tbody//*[contains(text(), '{phrase}')]"
+        return (By.XPATH, xpath)
+
+    def __init__(self, browser):
+        self.browser = browser
+
+    def active_filters_contains(self, filter_type):
+        active_filters = self.browser.find_element(*self.ACTIVE_FILTERS).text
+        return active_filters.find(filter_type)

--- a/test_filter.py
+++ b/test_filter.py
@@ -8,72 +8,79 @@ from selenium.webdriver import Chrome
 
 @pytest.fixture
 def browser():
-  driver = Chrome()
-  driver.implicitly_wait(10)
-  yield driver
-  driver.quit()
-  
-   
+    driver = Chrome()
+    driver.implicitly_wait(10)
+    yield driver
+    driver.quit()
+
+
 # fails due to bug in application
 
+
 def test_filter_by_series(browser):
-  
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters() 
-  
-  patchwork_page.filter_by_series('fix series querry')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('Series') > -1
-  
-# fails due to bug in application 
+
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_series("fix series querry")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("Series") > -1
+
+
+# fails due to bug in application
+
 
 def test_filter_by_submitter(browser):
 
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters() 
-     
-  patchwork_page.filter_by_submitter('Stephen Finucane')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('Submitter') > -1
-  
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_submitter("Stephen Finucane")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("Submitter") > -1
+
+
 def test_filter_by_state(browser):
-  
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters() 
-  
-  patchwork_page.filter_by_state('New')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('State') > 1
-  
+
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_state("New")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("State") > 1
+
+
 def test_filter_by_search_term(browser):
-  
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters()
-  
-  patchwork_page.filter_by_search_term('query')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('Search') > 1
-  
+
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_search_term("query")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("Search") > 1
+
+
 def test_filter_by_archived(browser):
-  
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters() 
-  
-  patchwork_page.filter_by_archived('both')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('Archived') > 1
-  
+
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_archived("both")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("Archived") > 1
+
+
 def test_filter_by_delegate(browser):
-  
-  patchwork_page = PatchworkHomePage(browser)
-  patchwork_page.load()
-  patchwork_page.show_filters() 
-  
-  patchwork_page.filter_by_delegate('Nobody')
-  filtered_results = FilteredPatchResults(browser)
-  assert filtered_results.active_filters_contains('Delegate') > 1
+
+    patchwork_page = PatchworkHomePage(browser)
+    patchwork_page.load()
+    patchwork_page.show_filters()
+
+    patchwork_page.filter_by_delegate("Nobody")
+    filtered_results = FilteredPatchResults(browser)
+    assert filtered_results.active_filters_contains("Delegate") > 1

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,6 @@ deps =
   flake8
 commands =
   flake8
+
+[flake8]
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36,style
+
+[testenv]
+deps =
+  pytest
+commands =
+  pytest
+
+[testenv:style]
+deps =
+  flake8
+commands =
+  flake8


### PR DESCRIPTION
Introduce some best practices in Python-land. Specifically, use 'tox' to run tests and 'pre-commit' to automatically validate code when committing. The former can be run like so:

```
tox -e py36
```

which will run the `py36` environment (`pytest` under Python 3.6). Alternatively, to run style checks on demand:

```
tox -e style
```

The latter can be installed like so:

```
pip install --user pre-commit
pre-commit install
```

Once installed, everytime you commit it will run style checks on the changed files. Very nifty, no?